### PR TITLE
Improve error messaging in WSConsume

### DIFF
--- a/src/main/java/org/jboss/ws/tools/cmd/WSConsume.java
+++ b/src/main/java/org/jboss/ws/tools/cmd/WSConsume.java
@@ -275,13 +275,13 @@ public class WSConsume
       }
       catch (Throwable t)
       {
-         System.err.println("Error: Could not import. (use --verbose to see full traces)");
+         System.err.println("Error: Could not import");
          if (!verbose)
          {
             String message = t.getMessage();
             if (message == null)
                message = t.getClass().getSimpleName();
-            System.err.println("Error: " + message);
+            System.err.println("Error: " + message + " (use --verbose to see full traces)");
          }
          else
          {


### PR DESCRIPTION
Hello, 

I was using WSConsume ant task and I saw an error like this. 

`Error: Could not import. (use --verbose to see full traces)`

I was confused, since verbose was already enabled for me. Looking at [this line](https://github.com/jbossws/jbossws-common-tools/blob/1e672e3ce84aa0a0420bff353dc9cb125843de5b/src/main/java/org/jboss/ws/tools/cmd/WSConsume.java#L278) , it appears that the this prompt shows up even when verbose is enabled. 

I have made a quick change and am only showing this prompt when verbose is disabled. 

PS: I am sorry, if this is not the protocol to create and solve issues here. I recon since this is very minor change we can resolve it via  a PR only. 