### PR TITLE
[JBWS-4509] - Upgrade jbossws-api from 3.0.0.Final to 3.1.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- Repository Deployment Settings -->
     <nexus.staging.tag>jbossws-common-tools-${project.version}</nexus.staging.tag>
     <!-- Dependency versions -->
-    <jbossws.api.version>3.0.0.Final</jbossws.api.version>
+    <jbossws.api.version>3.1.0.Beta1</jbossws.api.version>
     <ant.version>1.10.15</ant.version>
     <getopt.version>1.0.13</getopt.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
This is in the context of the changes/upgrades planned for the jbossws-cxf-7.4.0.Final release, see https://redhat.atlassian.net/browse/JBWS-4509