### PR TITLE
[JBWS-4510] - Adding maven-javadoc-plugin configuration to generate Javadoc artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
     <ant.version>1.10.15</ant.version>
     <getopt.version>1.0.13</getopt.version>
     <junit.version>4.13.2</junit.version>
+    <!-- Additional properties -->
+    <maven.javadoc.skip>false</maven.javadoc.skip>
   </properties>
 
   <!-- licenses -->
@@ -68,5 +70,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/JBWS-4510

Javadoc artifacts are needed in order to deploy to the JBoss Maven repo and Maven Central.
Belongs to the activities for the jbossws-cxf-7.4.0.Final release.